### PR TITLE
feat: don't require ua-parser-js in lambda-context

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,8 +70,5 @@
     "typescript": "5.6.3",
     "vitest": "2.1.5",
     "vitest-github-actions-reporter": "0.11.1"
-  },
-  "dependencies": {
-    "ua-parser-js": "^1.0.32"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,10 +7,6 @@ settings:
 importers:
 
   .:
-    dependencies:
-      ua-parser-js:
-        specifier: ^1.0.32
-        version: 1.0.39
     devDependencies:
       '@rollup/plugin-typescript':
         specifier: 12.1.1
@@ -1393,10 +1389,6 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  ua-parser-js@1.0.39:
-    resolution: {integrity: sha512-k24RCVWlEcjkdOxYmVJgeD/0a1TiSpqLg+ZalVGV9lsnr4yqu0w7tX/x2xX6G4zpkgQnRf89lxuZ1wsbjXM8lw==}
-    hasBin: true
-
   uglify-js@3.19.3:
     resolution: {integrity: sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==}
     engines: {node: '>=0.8.0'}
@@ -2755,8 +2747,6 @@ snapshots:
   typedarray@0.0.6: {}
 
   typescript@5.6.3: {}
-
-  ua-parser-js@1.0.39: {}
 
   uglify-js@3.19.3:
     optional: true

--- a/src/browser-context.ts
+++ b/src/browser-context.ts
@@ -1,18 +1,7 @@
 import { ExtendedClientApi, Plugin } from './client';
 import { BugsnagEvent } from './event';
 import { parseUserAgent } from './simple-ua-parser';
-
-export type UserAgentInfo = {
-  browserName?: string;
-  browserVersion?: string;
-  osName?: string;
-  osVersion?: string;
-  manufacturer?: string;
-  model?: string;
-  modelNumber?: string;
-};
-
-export type UserAgentParserFn = (userAgent: string) => UserAgentInfo;
+import type { UserAgentParserFn } from './user-agent-types';
 
 export const browserContextWithUaParser = (
   uaParser: UserAgentParserFn

--- a/src/index.ts
+++ b/src/index.ts
@@ -344,12 +344,7 @@ export { nodeNotifyUnhandledExceptions } from './node-unhandled-exceptions';
 
 // Other plugins
 export { appDuration } from './app-duration';
-export {
-  browserContext,
-  browserContextWithUaParser,
-  UserAgentParserFn,
-  UserAgentInfo,
-} from './browser-context';
+export { browserContext, browserContextWithUaParser } from './browser-context';
 export { deviceOrientation } from './deviceorientation';
 export { limitEvents } from './limit-events';
 export {
@@ -365,6 +360,7 @@ export {
   redactObject,
 } from './redact-keys';
 export { stringifyValues } from './stringify-values';
+export type { UserAgentParserFn, UserAgentInfo } from './user-agent-types';
 
 // Delivery plugins
 export { FetchDelivery } from './fetch-delivery';

--- a/src/simple-ua-parser.ts
+++ b/src/simple-ua-parser.ts
@@ -1,4 +1,4 @@
-import { UserAgentInfo } from './browser-context';
+import type { UserAgentInfo } from './user-agent-types';
 
 // The Bugsnag v5 API requires doing your own UA string parsing, requiring a
 // `browserName`, `browserVersion`, `osName`, `osVersion`, etc.

--- a/src/user-agent-types.ts
+++ b/src/user-agent-types.ts
@@ -1,0 +1,11 @@
+export type UserAgentInfo = {
+  browserName?: string;
+  browserVersion?: string;
+  osName?: string;
+  osVersion?: string;
+  manufacturer?: string;
+  model?: string;
+  modelNumber?: string;
+};
+
+export type UserAgentParserFn = (userAgent: string) => UserAgentInfo;


### PR DESCRIPTION
BREAKING CHANGE: If you want to continue to use `ua-parser-js` in
`lambda-context` you will need to use `lambdaContextWithUaParser` and
pass in your own parser function as described here:
https://github.com/birchill/bugsnag-zero?tab=readme-ov-file#using-a-custom-user-agent-string-parser

This is because from version `ua-parser-js` version 2 onwards, users are
required to either use the AGPL version or license the library.

It's best to allow users of this package to decide how they want to
consume `ua-parser-js`.
