### PR TITLE
make sure to pass up the same props that your component's constructor was passed

### DIFF
--- a/src/react.ts
+++ b/src/react.ts
@@ -114,7 +114,7 @@ function createClass<ComponentType, Element, ErrorBoundaryComponent>(
 ): ErrorBoundaryComponent {
   abstract class BugsnagErrorBoundaryComponent extends component {
     constructor(...args: any[]) {
-      super(args);
+      super(...args);
       this.state = {
         error: undefined,
         info: undefined,


### PR DESCRIPTION
This fixes this error:

When calling` super()` in `BugsnagErrorBoundaryComponent`, make sure to pass up the same props that your component's constructor was passed.

